### PR TITLE
Remove deprecation warnings in puppet 8

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,6 +1,10 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
 hierarchy:
   - name: "Operating System Major Version"
     backend: yaml

--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,6 @@
       "version_requirement": ">= 4.2.0 < 8.0.0"
     }
   ],
-  "data_provider": "hiera",
-  "description": "Install and configure the System Security Services Daemon",
   "tags": [
     "sssd"
   ],


### PR DESCRIPTION
Make the module puppet 8 compatible by bumping hiera to version 5 and removing an obsolete definition from metadata.json