### PR TITLE
Use stdlib::ensure_packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,6 +6,6 @@ class sssd::install {
     ensure => $sssd::package_ensure,
   }
 
-  ensure_packages($sssd::required_packages)
+  stdlib::ensure_packages($sssd::required_packages)
 
 }


### PR DESCRIPTION
ensure_packages has been deprecated in Puppet 8